### PR TITLE
Expand/collapse all items at once

### DIFF
--- a/src/Explore/Detailed.js
+++ b/src/Explore/Detailed.js
@@ -3,7 +3,14 @@ import { Suspense } from 'react'
 
 import useApi from '../Api/useApi'
 import Spinner from '../App/Spinner'
+import { parseDate } from '../App/helpers'
 import { Text, Flex, Box } from '../Primitives'
+
+const getMembers = (data) =>
+  data.members.map((member) => ({
+    ...member?.affiliation,
+    ...member?.person,
+  }))
 
 function Table({ table }) {
   const { url, columns, mergeFn, rowId: id, config } = table
@@ -40,6 +47,7 @@ function Table({ table }) {
     </Flex>
   )
 }
+
 function Title({ expand, onClick, text }) {
   return (
     <Text onClick={onClick} fontWeight="bold">
@@ -47,22 +55,39 @@ function Title({ expand, onClick, text }) {
     </Text>
   )
 }
-function Details(props) {
-  const { open, title } = props
-  const [expanded, toggle] = useToggle(open)
+
+function Detailed(props) {
+  const { pid, summary, releaseDate } = props
+  const [expanded, toggle] = useToggle(false)
+
   return (
-    <Box
-      sx={{
-        cursor: 'pointer',
-      }}
-      onClick={() => toggle()}
-    >
-      <Title expand={expanded} text={title} />
-      <Suspense fallback={<Spinner />}>
-        {expanded && <Table table={props} />}
-      </Suspense>
-    </Box>
+    <>
+      <Box as="article">{summary}</Box>
+      <br />
+      <Text sx={{ fontWeight: 'bold' }}>
+        Released: {parseDate(releaseDate)}
+      </Text>
+      <Box sx={{ cursor: 'pointer' }} onClick={() => toggle()}>
+        <Title expand={expanded} text="Members" />
+        <Suspense fallback={<Spinner />}>
+          {expanded && (
+            <Table
+              table={{
+                columns: [
+                  ['Person', 'fullName'],
+                  ['Affiliation', 'name'],
+                ],
+                url: `/documents/${encodeURIComponent(pid)}`,
+                mergeFn: getMembers,
+                rowId: 'id',
+                config: { include: ['person', 'affiliation'] },
+              }}
+            />
+          )}
+        </Suspense>
+      </Box>
+    </>
   )
 }
 
-export default Details
+export default Detailed

--- a/src/Explore/DocumentItem.js
+++ b/src/Explore/DocumentItem.js
@@ -1,66 +1,19 @@
-import { useState } from 'react'
+import { useRef } from 'react'
 
-import { parseDate } from '../App/helpers'
 import { Card, Box, Flex, Heading, Link, Text } from '../Primitives'
-import Details from './Detail'
+import Detailed from './Detailed'
+import Simple from './Simple'
 
-const getMembers = (data) =>
-  data.members.map((member) => ({
-    ...member?.affiliation,
-    ...member?.person,
-  }))
-
-function DocumentItem({ document }) {
-  const { pid, title, score, doi, summary, releaseDate } = document
-  const [showDetail, setShowDetail] = useState(false)
+function DocumentItem(props) {
+  const { document, detailedMode, toggleMode } = props
+  const { pid, title, score, doi } = document
 
   const doiLink = `http://doi.org/${doi}`
-  function Detailed() {
-    return (
-      <>
-        <Box as="article">{summary}</Box>
-        <br />
-        <Text sx={{ fontWeight: 'bold' }}>
-          Released: {parseDate(releaseDate)}
-        </Text>
-        <Details
-          columns={[
-            ['Person', 'fullName'],
-            ['Affiliation', 'name'],
-          ]}
-          url={`/documents/${encodeURIComponent(pid)}`}
-          mergeFn={getMembers}
-          rowId="id"
-          title="Members"
-          config={{ include: ['person', 'affiliation'] }}
-        />
-      </>
-    )
-  }
-  function Simple() {
-    return (
-      <>
-        <Box
-          sx={{
-            display: '-webkit-box',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            '-webkit-line-clamp': '2',
-            '-webkit-box-orient': 'vertical',
-          }}
-        >
-          {summary}
-        </Box>
-        <br />
-        <Text sx={{ fontStyle: 'italic' }}>
-          Released: {parseDate(releaseDate)}
-        </Text>
-      </>
-    )
-  }
+  const itemRef = useRef(null)
 
   return (
     <Box
+      ref={itemRef}
       as="article"
       sx={{
         display: ['block', 'flex'],
@@ -86,18 +39,20 @@ function DocumentItem({ document }) {
           target="_blank"
           sx={{
             display: 'block',
-            whiteSpace: showDetail ? 'wrap' : 'nowrap',
-            overflow: showDetail ? 'visible' : 'hidden',
-            textOverflow: showDetail ? 'none' : 'ellipsis',
+            whiteSpace: detailedMode ? 'wrap' : 'nowrap',
+            overflow: detailedMode ? 'visible' : 'hidden',
+            textOverflow: detailedMode ? 'none' : 'ellipsis',
             textDecoration: 'none',
           }}
         >
           {title}
         </Heading>
-        <Box>{showDetail ? <Detailed /> : <Simple />}</Box>
+        <Box>
+          {detailedMode ? <Detailed {...document} /> : <Simple {...document} />}
+        </Box>
         <br />
         <Box
-          onClick={() => setShowDetail(!showDetail)}
+          onClick={() => toggleMode(itemRef.current)}
           sx={{
             cursor: 'pointer',
             borderTop: '1px solid',
@@ -111,7 +66,7 @@ function DocumentItem({ document }) {
             },
           }}
         >
-          <strong>{showDetail ? '\u2227' : '\u2228'}</strong>
+          <strong>{detailedMode ? '\u2227' : '\u2228'}</strong>
         </Box>
       </Card>
     </Box>

--- a/src/Explore/DocumentList.js
+++ b/src/Explore/DocumentList.js
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useLayoutEffect, useRef } from 'react'
 
+import { useToggle } from '../../node_modules/@react-hookz/web/cjs'
 import useApi from '../Api/useApi'
 import useFilters from '../Api/useFilters'
 import { useSearchStore } from '../App/stores'
@@ -10,6 +11,24 @@ function DocumentList() {
   const setCount = useSearchStore((state) => state.setCount)
   const filters = useFilters()
   const { data } = useApi('/documents', filters)
+
+  const [detailedMode, toggleMode] = useToggle(false)
+  const toggledItem = useRef(null)
+
+  function handleToggleMode(item) {
+    toggledItem.current = { item, offset: item.getBoundingClientRect().y }
+    toggleMode()
+  }
+
+  useLayoutEffect(() => {
+    if (toggledItem.current) {
+      // Restore scroll position when toggling mode
+      const { item, offset } = toggledItem.current
+      item.scrollIntoView()
+      window.scrollBy(0, -offset)
+      toggledItem.current = null
+    }
+  }, [detailedMode])
 
   useEffect(() => {
     setCount(data.length)
@@ -24,7 +43,12 @@ function DocumentList() {
         </Card>
       ) : (
         data.map((document) => (
-          <DocumentItem document={document} key={document.pid} />
+          <DocumentItem
+            key={document.pid}
+            document={document}
+            detailedMode={detailedMode}
+            toggleMode={handleToggleMode}
+          />
         ))
       )}
     </Flex>

--- a/src/Explore/Simple.js
+++ b/src/Explore/Simple.js
@@ -1,0 +1,26 @@
+import { parseDate } from '../App/helpers'
+import { Box, Text } from '../Primitives'
+
+function Simple({ summary, releaseDate }) {
+  return (
+    <>
+      <Box
+        sx={{
+          display: '-webkit-box',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          '-webkit-line-clamp': '2',
+          '-webkit-box-orient': 'vertical',
+        }}
+      >
+        {summary}
+      </Box>
+      <br />
+      <Text sx={{ fontStyle: 'italic' }}>
+        Released: {parseDate(releaseDate)}
+      </Text>
+    </>
+  )
+}
+
+export default Simple


### PR DESCRIPTION
To keep the scrolling position after toggling all items, the code keeps track of the item that triggered the expansion/collapse and saves its offset. Then, once the expand/collapse state is toggled, there's a layout effect that scrolls the item into view and then applies the saved scroll offset.