### PR TITLE
Tweak members accordion in detailed view

### DIFF
--- a/src/App/helpers.js
+++ b/src/App/helpers.js
@@ -2,7 +2,7 @@ import { format, isValid } from 'date-fns'
 
 export function parseDate(date) {
   const dateObj = new Date(date)
-  return isValid(dateObj) ? format(dateObj, 'dd. MM. yyyy') : 'not available'
+  return isValid(dateObj) ? format(dateObj, 'd MMM yyyy') : 'not available'
 }
 
 export function capitalizeAndSpace(str) {

--- a/src/Explore/DocumentItem.js
+++ b/src/Explore/DocumentItem.js
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
 
 import { Card, Box, Flex, Heading, Link, Text } from '../Primitives'
 import Detailed from './Detailed'
@@ -58,15 +59,15 @@ function DocumentItem(props) {
             borderTop: '1px solid',
             borderColor: 'foreground',
             textAlign: 'center',
-            fontSize: 0,
+            fontSize: 2,
             mx: -3,
-            mb: -3,
+            mb: '-20px',
             ':hover': {
               bg: 'foreground',
             },
           }}
         >
-          <strong>{detailedMode ? '\u2227' : '\u2228'}</strong>
+          {detailedMode ? <FiChevronUp /> : <FiChevronDown />}
         </Box>
       </Card>
     </Box>


### PR DESCRIPTION
- Replaced the chevrons with icons
- Added an error boundary so the results don't all disappear when the members can't be fetched
- Used a button for the trigger and made it so only the button is clickable

![image](https://user-images.githubusercontent.com/2936402/173781342-5046a3a7-e92c-4672-8786-fe6ef1c2ca42.png)