### PR TITLE
fixed ess panosc API url

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -8,7 +8,7 @@
   {
     "name": "European Spallation Source",
     "abbr": "ESS",
-    "source": "https://scicat.ess.eu/panosc-api",
+    "source": "https://search.panosc.ess.eu/api",
     "link": "https://europeanspallationsource.se/"
   },
   {


### PR DESCRIPTION
We at ESS have moved our PaNOSC url and therefore the feature of showing where a dataset is coming from has broken