### PR TITLE
removed event counter field

### DIFF
--- a/src/filters.json
+++ b/src/filters.json
@@ -56,13 +56,6 @@
     "units": ["Pa"]
   },
   {
-    "id": "count_events",
-    "field": "count_events",
-    "display": "count_events",
-    "group": "parameters",
-    "type": "numeric"
-  },
-  {
     "id": "limit",
     "field": "limit"
   }


### PR DESCRIPTION
This PR remove the filter on event counter which is not a standard filter per PaNOSC documentation