### PR TITLE
added option to provide unit label and value

### DIFF
--- a/src/Search/Numeric.js
+++ b/src/Search/Numeric.js
@@ -57,6 +57,11 @@ function Numeric({ obj }) {
     500,
   )
 
+  const defaultUnitVL = ( defaultUnit.includes("|") ? defaultUnit.split("|") : [defaultUnit, defaultUnit] );
+  const otherUnitsVL = otherUnits.map((value) => (
+    ( value.includes("|") ? value.split("|") : [value, value] )
+  ))
+
   return (
     <FilterBox title={display || id} isActive={isActive}>
       <Box id={`form-${id}`} as="form" onSubmit={(e) => e.preventDefault()}>
@@ -95,9 +100,9 @@ function Numeric({ obj }) {
                 fontSize={0}
               >
                 <option value="">-</option>
-                <option key={defaultUnit}>{defaultUnit}</option>
-                {otherUnits.map((str) => (
-                  <option key={str}>{str}</option>
+                <option value={defaultUnitVL[0]} key={defaultUnitVL[0]}>{defaultUnitVL[1]}</option>
+                {otherUnitsVL.map((item) => (
+                  <option value={item[0]} key={item[0]}>{item[1]}</option>
                 ))}
               </Select>
             )}

--- a/src/filters.json
+++ b/src/filters.json
@@ -22,7 +22,7 @@
     "display": "Incident Wavelength",
     "type": "numeric",
     "group": "parameters",
-    "units": ["nm", "pm", "Å"]
+    "units": ["nm", "pm", "angstrom|Å"]
   },
   {
     "id": "incident_photon_energy",


### PR DESCRIPTION
With this PR, we can provide a value that is different than the label for the parameter units.
In file src/filter.json, we can specify units for each numeric parameter.
The units entry is an array of strings.
If the string contains the character "|", it will be split at such character. the first portion is used as value of the select box which will be used to build the query for the backend. The second element is the label show to the user.
If the item is a string with no "|", than the same value will be used for the value and label in the select.