### PR TITLE
Add Jupyter SLURM service for ESRF provider

### DIFF
--- a/src/Explore/Services.js
+++ b/src/Explore/Services.js
@@ -18,14 +18,7 @@ const multiChecker = (...urls) =>
   )
 
 const injectId = (id, template) => {
-  if (!template) {
-    return
-  }
-  if (!template.includes('%')) {
-    throw new Error('Invalid service template')
-  }
-  const [prefix, suffix] = template.split('%')
-  return suffix ? prefix + id + suffix : prefix + id
+  return template ? template.replace('__PID__', id) : undefined
 }
 
 function Services({ provider, pid: unsafePID }) {

--- a/src/providers.json
+++ b/src/providers.json
@@ -3,7 +3,13 @@
     "name": "European Synchrotron Radiation Facility",
     "abbr": "ESRF",
     "url": "https://icatplus.esrf.fr/api",
-    "homepage": "https://www.esrf.eu/"
+    "homepage": "https://www.esrf.eu/",
+    "services": [
+      {
+        "name": "Jupyter SLURM",
+        "url": "https://jupyter-slurm.esrf.fr/spawn?partition_simple=jupyter-nice&nprocs_simple=1&environment_simple=system&jupyterlab_simple=on&runtime_simple=1&partition=jupyter-nice&nprocs=1&runtime=1%3A00%3A00&default_url=%2Flab"
+      }
+    ]
   },
   {
     "name": "European Spallation Source",


### PR DESCRIPTION
I couldn't find the information I needed in order to start JupyterLab inside the proposal's folder. This would be the name of the beamline on which the experiment was run, and the name of the proposal. The name of the proposal is currently returned as the title for some reason, but inconsistently (sometimes the dash is missing). The beamline is not returned at all.