### PR TITLE
add service block with EuXFEL-VISA link (global) to providers.json

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -45,6 +45,12 @@
     "name": "European XFEL",
     "abbr": "EuXFEL",
     "url": "https://in.xfel.eu/metadata/api/panosc/v1",
-    "homepage": "https://www.xfel.eu/index_eng.html"
+    "homepage": "https://www.xfel.eu/index_eng.html",
+    "services": [
+      {
+        "name": "VISA",
+        "url": "https://visa.xfel.eu"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
At the moment a global link should be sufficient due to the single example proposal with all open (demo) data.
@jirimajer , @axelboc could you make a mini-review? 😄 