### PR TITLE
Add Eli Beamlines to providers

### DIFF
--- a/src/providers.json
+++ b/src/providers.json
@@ -94,5 +94,21 @@
         "url": "https://software.pan-data.eu/"
       }
     ]
+  },
+  {
+    "name": "ELI Beamlines",
+    "abbr": "ELIBL",
+    "url": "https://searchapi.k8s.eli-beams.eu/api",
+    "homepage": "https://eli-beams.eu/",
+    "services": [
+      {
+        "name": "PaNdata Software Catalogue",
+        "url": "https://software.pan-data.eu/"
+      },
+      {
+        "name": "VISA",
+        "url": "https://visa.k8s.eli-beams.eu/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
![not in homepage](https://user-images.githubusercontent.com/27091643/204189591-85837400-a915-4190-b48c-c182133be7b7.png)
![fake eli](https://user-images.githubusercontent.com/27091643/204189070-99c40945-ef10-4fd9-a7c7-2649a92ea90e.png)

This adds Eli Beamlines to providers on the frontend. Since we don't have a data catalogue to connect to, the local search api instance only carries the "default" mock data. Search api scoring is obviously not deployed and neither is the local endpoint recognized by the federated one.

The result is that the Eli endpoint doesn't show up on the homepage (as that list is based on the state of the federated endpoint) and isn't really searchable either but if you specify the Eli Beamlines facility, you then get to see the two mock documents with visa listed among services.